### PR TITLE
Add actual moon monk robes

### DIFF
--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobes - 0008CB_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobes - 0008CB_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,34 @@
+FormKey: 0008CB:GTS CE - Easy Mode.esp
+EditorID: CE_0K_KhajiitRobes
+Name:
+  TargetLanguage: English
+  Value: Moon Monk's Robes
+WorldModel:
+  Male:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+  Female:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+BodyTemplate:
+  FirstPersonFlags:
+  - Body
+  ArmorType: Clothing
+  ActsLike44: True
+Race: 000019:Skyrim.esm
+Keywords:
+- 06BBE8:Skyrim.esm
+- 0A8657:Skyrim.esm
+- 0A865D:Skyrim.esm
+- 08F95B:Skyrim.esm
+- 002ED9:Update.esm
+Description:
+  TargetLanguage: English
+  Value: ''
+Armature:
+- 000800:Kad_MoonMonkRobes.esp
+- 000809:Kad_MoonMonkRobes.esp
+Value: 270
+Weight: 4

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesAnequina - 0008CC_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesAnequina - 0008CC_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,37 @@
+FormKey: 0008CC:GTS CE - Easy Mode.esp
+EditorID: CE_0K_KhajiitRobesAnequina
+Name:
+  TargetLanguage: English
+  Value: Moon Monk's Robes - Anequina Sunset
+WorldModel:
+  Male:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+      AlternateTextures:
+      - Name: Torso2.003
+        NewTexture: 000815:Kad_MoonMonkRobes.esp
+        Index: 1
+      - Name: torso
+        NewTexture: 000814:Kad_MoonMonkRobes.esp
+BodyTemplate:
+  FirstPersonFlags:
+  - Body
+  ArmorType: Clothing
+  ActsLike44: True
+Race: 000019:Skyrim.esm
+Keywords:
+- 06BBE8:Skyrim.esm
+- 08F95B:Skyrim.esm
+- 0A8657:Skyrim.esm
+- 0A865D:Skyrim.esm
+- 002ED9:Update.esm
+Description:
+  TargetLanguage: English
+  Value: ''
+Armature:
+- 000820:Kad_MoonMonkRobes.esp
+- 000821:Kad_MoonMonkRobes.esp
+Value: 270
+Weight: 4
+ArmorRating: 29

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesAssassin - 0008CD_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesAssassin - 0008CD_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,37 @@
+FormKey: 0008CD:GTS CE - Easy Mode.esp
+EditorID: CE_0K_KhajiitRobesAssassin
+Name:
+  TargetLanguage: English
+  Value: Moon Monk's Robes - Assassin
+WorldModel:
+  Male:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+      AlternateTextures:
+      - Name: Torso2.003
+        NewTexture: 000845:Kad_MoonMonkRobes.esp
+        Index: 1
+      - Name: torso
+        NewTexture: 000888:Kad_MoonMonkRobes.esp
+BodyTemplate:
+  FirstPersonFlags:
+  - Body
+  ArmorType: Clothing
+  ActsLike44: True
+Race: 000019:Skyrim.esm
+Keywords:
+- 06BBE8:Skyrim.esm
+- 08F95B:Skyrim.esm
+- 0A8657:Skyrim.esm
+- 0A865D:Skyrim.esm
+- 002ED9:Update.esm
+Description:
+  TargetLanguage: English
+  Value: ''
+Armature:
+- 000889:Kad_MoonMonkRobes.esp
+- 00088A:Kad_MoonMonkRobes.esp
+Value: 270
+Weight: 4
+ArmorRating: 29

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesBlack - 0008D4_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesBlack - 0008D4_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,37 @@
+FormKey: 0008D4:GTS CE - Easy Mode.esp
+EditorID: CE_0K_KhajiitRobesBlack
+Name:
+  TargetLanguage: English
+  Value: Moon Monk's Robes - Rajhin's Shadow
+WorldModel:
+  Male:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+      AlternateTextures:
+      - Name: Torso2.003
+        NewTexture: 000845:Kad_MoonMonkRobes.esp
+        Index: 1
+      - Name: torso
+        NewTexture: 000844:Kad_MoonMonkRobes.esp
+BodyTemplate:
+  FirstPersonFlags:
+  - Body
+  ArmorType: Clothing
+  ActsLike44: True
+Race: 000019:Skyrim.esm
+Keywords:
+- 06BBE8:Skyrim.esm
+- 08F95B:Skyrim.esm
+- 0A8657:Skyrim.esm
+- 0A865D:Skyrim.esm
+- 002ED9:Update.esm
+Description:
+  TargetLanguage: English
+  Value: ''
+Armature:
+- 000853:Kad_MoonMonkRobes.esp
+- 000854:Kad_MoonMonkRobes.esp
+Value: 270
+Weight: 4
+ArmorRating: 29

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesJadarri - 0008D2_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesJadarri - 0008D2_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,37 @@
+FormKey: 0008D2:GTS CE - Easy Mode.esp
+EditorID: CE_0K_KhajiitRobesJadarri
+Name:
+  TargetLanguage: English
+  Value: Moon Monk's Robes - Pride of Alkosh
+WorldModel:
+  Male:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+      AlternateTextures:
+      - Name: Torso2.003
+        NewTexture: 000879:Kad_MoonMonkRobes.esp
+        Index: 1
+      - Name: torso
+        NewTexture: 000878:Kad_MoonMonkRobes.esp
+BodyTemplate:
+  FirstPersonFlags:
+  - Body
+  ArmorType: Clothing
+  ActsLike44: True
+Race: 000019:Skyrim.esm
+Keywords:
+- 06BBE8:Skyrim.esm
+- 08F95B:Skyrim.esm
+- 0A8657:Skyrim.esm
+- 0A865D:Skyrim.esm
+- 002ED9:Update.esm
+Description:
+  TargetLanguage: English
+  Value: ''
+Armature:
+- 00087D:Kad_MoonMonkRobes.esp
+- 00087E:Kad_MoonMonkRobes.esp
+Value: 270
+Weight: 4
+ArmorRating: 29

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesLightRed - 0008CE_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesLightRed - 0008CE_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,37 @@
+FormKey: 0008CE:GTS CE - Easy Mode.esp
+EditorID: CE_0K_KhajiitRobesLightRed
+Name:
+  TargetLanguage: English
+  Value: Moon Monk's Robes - Imperial Emissary
+WorldModel:
+  Male:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+      AlternateTextures:
+      - Name: Torso2.003
+        NewTexture: 000841:Kad_MoonMonkRobes.esp
+        Index: 1
+      - Name: torso
+        NewTexture: 000849:Kad_MoonMonkRobes.esp
+BodyTemplate:
+  FirstPersonFlags:
+  - Body
+  ArmorType: Clothing
+  ActsLike44: True
+Race: 000019:Skyrim.esm
+Keywords:
+- 06BBE8:Skyrim.esm
+- 08F95B:Skyrim.esm
+- 0A8657:Skyrim.esm
+- 0A865D:Skyrim.esm
+- 002ED9:Update.esm
+Description:
+  TargetLanguage: English
+  Value: ''
+Armature:
+- 000863:Kad_MoonMonkRobes.esp
+- 000862:Kad_MoonMonkRobes.esp
+Value: 270
+Weight: 4
+ArmorRating: 29

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesRakazra - 0008D3_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesRakazra - 0008D3_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,37 @@
+FormKey: 0008D3:GTS CE - Easy Mode.esp
+EditorID: CE_0K_KhajiitRobesRakazra
+Name:
+  TargetLanguage: English
+  Value: Moon Monk's Robes - Ra'kazra's Might
+WorldModel:
+  Male:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+      AlternateTextures:
+      - Name: Torso2.003
+        NewTexture: 000811:Kad_MoonMonkRobes.esp
+        Index: 1
+      - Name: torso
+        NewTexture: 000810:Kad_MoonMonkRobes.esp
+BodyTemplate:
+  FirstPersonFlags:
+  - Body
+  ArmorType: Clothing
+  ActsLike44: True
+Race: 000019:Skyrim.esm
+Keywords:
+- 06BBE8:Skyrim.esm
+- 08F95B:Skyrim.esm
+- 0A8657:Skyrim.esm
+- 0A865D:Skyrim.esm
+- 002ED9:Update.esm
+Description:
+  TargetLanguage: English
+  Value: Garments styled after an ancient guardian of Elsweyr.
+Armature:
+- 000819:Kad_MoonMonkRobes.esp
+- 00081A:Kad_MoonMonkRobes.esp
+Value: 270
+Weight: 4
+ArmorRating: 29

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesRed - 0008D1_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesRed - 0008D1_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,37 @@
+FormKey: 0008D1:GTS CE - Easy Mode.esp
+EditorID: CE_0K_KhajiitRobesRed
+Name:
+  TargetLanguage: English
+  Value: Moon Monk's Robes - Nahfahlaar's Flame
+WorldModel:
+  Male:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+      AlternateTextures:
+      - Name: Torso2.003
+        NewTexture: 00083D:Kad_MoonMonkRobes.esp
+        Index: 1
+      - Name: torso
+        NewTexture: 00083C:Kad_MoonMonkRobes.esp
+BodyTemplate:
+  FirstPersonFlags:
+  - Body
+  ArmorType: Clothing
+  ActsLike44: True
+Race: 000019:Skyrim.esm
+Keywords:
+- 06BBE8:Skyrim.esm
+- 08F95B:Skyrim.esm
+- 0A8657:Skyrim.esm
+- 0A865D:Skyrim.esm
+- 002ED9:Update.esm
+Description:
+  TargetLanguage: English
+  Value: ''
+Armature:
+- 00085D:Kad_MoonMonkRobes.esp
+- 00085E:Kad_MoonMonkRobes.esp
+Value: 270
+Weight: 4
+ArmorRating: 29

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesRegal - 0008D5_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesRegal - 0008D5_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,37 @@
+FormKey: 0008D5:GTS CE - Easy Mode.esp
+EditorID: CE_0K_KhajiitRobesRegal
+Name:
+  TargetLanguage: English
+  Value: Moon Monk's Robes - Regal
+WorldModel:
+  Male:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+      AlternateTextures:
+      - Name: Torso2.003
+        NewTexture: 000826:Kad_MoonMonkRobes.esp
+        Index: 1
+      - Name: torso
+        NewTexture: 000825:Kad_MoonMonkRobes.esp
+BodyTemplate:
+  FirstPersonFlags:
+  - Body
+  ArmorType: Clothing
+  ActsLike44: True
+Race: 000019:Skyrim.esm
+Keywords:
+- 06BBE8:Skyrim.esm
+- 08F95B:Skyrim.esm
+- 0A8657:Skyrim.esm
+- 0A865D:Skyrim.esm
+- 002ED9:Update.esm
+Description:
+  TargetLanguage: English
+  Value: ''
+Armature:
+- 00082E:Kad_MoonMonkRobes.esp
+- 00082F:Kad_MoonMonkRobes.esp
+Value: 270
+Weight: 4
+ArmorRating: 29

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesWater - 0008D6_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesWater - 0008D6_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,37 @@
+FormKey: 0008D6:GTS CE - Easy Mode.esp
+EditorID: CE_0K_KhajiitRobesWater
+Name:
+  TargetLanguage: English
+  Value: Moon Monk's Robes - Water Clan
+WorldModel:
+  Male:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+      AlternateTextures:
+      - Name: Torso2.003
+        NewTexture: 000829:Kad_MoonMonkRobes.esp
+        Index: 1
+      - Name: torso
+        NewTexture: 000828:Kad_MoonMonkRobes.esp
+BodyTemplate:
+  FirstPersonFlags:
+  - Body
+  ArmorType: Clothing
+  ActsLike44: True
+Race: 000019:Skyrim.esm
+Keywords:
+- 06BBE8:Skyrim.esm
+- 08F95B:Skyrim.esm
+- 0A8657:Skyrim.esm
+- 0A865D:Skyrim.esm
+- 002ED9:Update.esm
+Description:
+  TargetLanguage: English
+  Value: ''
+Armature:
+- 000836:Kad_MoonMonkRobes.esp
+- 000837:Kad_MoonMonkRobes.esp
+Value: 270
+Weight: 4
+ArmorRating: 29

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesWaterALT - 0008D0_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesWaterALT - 0008D0_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,37 @@
+FormKey: 0008D0:GTS CE - Easy Mode.esp
+EditorID: CE_0K_KhajiitRobesWaterALT
+Name:
+  TargetLanguage: English
+  Value: Moon Monk's Robes - Khenarthi's Breath
+WorldModel:
+  Male:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+      AlternateTextures:
+      - Name: Torso2.003
+        NewTexture: 00084A:Kad_MoonMonkRobes.esp
+        Index: 1
+      - Name: torso
+        NewTexture: 000828:Kad_MoonMonkRobes.esp
+BodyTemplate:
+  FirstPersonFlags:
+  - Body
+  ArmorType: Clothing
+  ActsLike44: True
+Race: 000019:Skyrim.esm
+Keywords:
+- 06BBE8:Skyrim.esm
+- 08F95B:Skyrim.esm
+- 0A8657:Skyrim.esm
+- 0A865D:Skyrim.esm
+- 002ED9:Update.esm
+Description:
+  TargetLanguage: English
+  Value: ''
+Armature:
+- 000871:Kad_MoonMonkRobes.esp
+- 000872:Kad_MoonMonkRobes.esp
+Value: 270
+Weight: 4
+ArmorRating: 29

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesWhite - 0008CF_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Armors/CE_0K_KhajiitRobesWhite - 0008CF_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,37 @@
+FormKey: 0008CF:GTS CE - Easy Mode.esp
+EditorID: CE_0K_KhajiitRobesWhite
+Name:
+  TargetLanguage: English
+  Value: Moon Monk's Robes - Jone's Light
+WorldModel:
+  Male:
+    Model:
+      File: armor\Kad_KhajiitMonk\Robes_gnd.nif
+      Data: 0x020000000000000000000000
+      AlternateTextures:
+      - Name: Torso2.003
+        NewTexture: 00084A:Kad_MoonMonkRobes.esp
+        Index: 1
+      - Name: torso
+        NewTexture: 000849:Kad_MoonMonkRobes.esp
+BodyTemplate:
+  FirstPersonFlags:
+  - Body
+  ArmorType: Clothing
+  ActsLike44: True
+Race: 000019:Skyrim.esm
+Keywords:
+- 06BBE8:Skyrim.esm
+- 08F95B:Skyrim.esm
+- 0A8657:Skyrim.esm
+- 0A865D:Skyrim.esm
+- 002ED9:Update.esm
+Description:
+  TargetLanguage: English
+  Value: ''
+Armature:
+- 000859:Kad_MoonMonkRobes.esp
+- 000858:Kad_MoonMonkRobes.esp
+Value: 270
+Weight: 4
+ArmorRating: 29

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesAnequina - 0008D7_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesAnequina - 0008D7_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,27 @@
+FormKey: 0008D7:GTS CE - Easy Mode.esp
+EditorID: CE_0RecipeArmorKhajiitRobesAnequina
+Items:
+- Item:
+    Item: 05AD9E:Skyrim.esm
+    Count: 2
+- Item:
+    Item: 05AD9F:Skyrim.esm
+    Count: 1
+- Item:
+    Item: 6CE001:Update.esm
+    Count: 8
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 00088C:Kad_MoonMonkRobes.esp
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  Unknown2: 84
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 0CB40F:Skyrim.esm
+  ComparisonValue: 1
+CreatedObject: 0008CC:GTS CE - Easy Mode.esp
+WorkbenchKeyword: 6CE000:Update.esm
+CreatedObjectCount: 1

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesAssassin - 0008D8_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesAssassin - 0008D8_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,27 @@
+FormKey: 0008D8:GTS CE - Easy Mode.esp
+EditorID: CE_0RecipeArmorKhajiitRobesAssassin
+Items:
+- Item:
+    Item: 05AD9E:Skyrim.esm
+    Count: 2
+- Item:
+    Item: 05AD9F:Skyrim.esm
+    Count: 1
+- Item:
+    Item: 6CE001:Update.esm
+    Count: 8
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 00088C:Kad_MoonMonkRobes.esp
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  Unknown2: 84
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 0CB40F:Skyrim.esm
+  ComparisonValue: 1
+CreatedObject: 0008CD:GTS CE - Easy Mode.esp
+WorkbenchKeyword: 6CE000:Update.esm
+CreatedObjectCount: 1

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesBlack - 0008D9_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesBlack - 0008D9_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,27 @@
+FormKey: 0008D9:GTS CE - Easy Mode.esp
+EditorID: CE_0RecipeArmorKhajiitRobesBlack
+Items:
+- Item:
+    Item: 05AD9E:Skyrim.esm
+    Count: 2
+- Item:
+    Item: 05AD9F:Skyrim.esm
+    Count: 1
+- Item:
+    Item: 6CE001:Update.esm
+    Count: 8
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 00088C:Kad_MoonMonkRobes.esp
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  Unknown2: 84
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 0CB40F:Skyrim.esm
+  ComparisonValue: 1
+CreatedObject: 0008D4:GTS CE - Easy Mode.esp
+WorkbenchKeyword: 6CE000:Update.esm
+CreatedObjectCount: 1

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesJadarri - 0008DA_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesJadarri - 0008DA_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,27 @@
+FormKey: 0008DA:GTS CE - Easy Mode.esp
+EditorID: CE_0RecipeArmorKhajiitRobesJadarri
+Items:
+- Item:
+    Item: 05AD9E:Skyrim.esm
+    Count: 2
+- Item:
+    Item: 05AD9F:Skyrim.esm
+    Count: 1
+- Item:
+    Item: 6CE001:Update.esm
+    Count: 8
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 00088C:Kad_MoonMonkRobes.esp
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  Unknown2: 84
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 0CB40F:Skyrim.esm
+  ComparisonValue: 1
+CreatedObject: 0008D2:GTS CE - Easy Mode.esp
+WorkbenchKeyword: 6CE000:Update.esm
+CreatedObjectCount: 1

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesLightRed - 0008DB_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesLightRed - 0008DB_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,27 @@
+FormKey: 0008DB:GTS CE - Easy Mode.esp
+EditorID: CE_0RecipeArmorKhajiitRobesLightRed
+Items:
+- Item:
+    Item: 05AD9E:Skyrim.esm
+    Count: 2
+- Item:
+    Item: 05AD9F:Skyrim.esm
+    Count: 1
+- Item:
+    Item: 6CE001:Update.esm
+    Count: 8
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 00088C:Kad_MoonMonkRobes.esp
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  Unknown2: 84
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 0CB40F:Skyrim.esm
+  ComparisonValue: 1
+CreatedObject: 0008CE:GTS CE - Easy Mode.esp
+WorkbenchKeyword: 6CE000:Update.esm
+CreatedObjectCount: 1

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesRakazra - 0008DC_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesRakazra - 0008DC_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,27 @@
+FormKey: 0008DC:GTS CE - Easy Mode.esp
+EditorID: CE_0RecipeArmorKhajiitRobesRakazra
+Items:
+- Item:
+    Item: 05AD9E:Skyrim.esm
+    Count: 2
+- Item:
+    Item: 05AD9F:Skyrim.esm
+    Count: 1
+- Item:
+    Item: 6CE001:Update.esm
+    Count: 8
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 00088C:Kad_MoonMonkRobes.esp
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  Unknown2: 84
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 0CB40F:Skyrim.esm
+  ComparisonValue: 1
+CreatedObject: 0008D3:GTS CE - Easy Mode.esp
+WorkbenchKeyword: 6CE000:Update.esm
+CreatedObjectCount: 1

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesRed - 0008DD_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesRed - 0008DD_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,27 @@
+FormKey: 0008DD:GTS CE - Easy Mode.esp
+EditorID: CE_0RecipeArmorKhajiitRobesRed
+Items:
+- Item:
+    Item: 05AD9E:Skyrim.esm
+    Count: 2
+- Item:
+    Item: 05AD9F:Skyrim.esm
+    Count: 1
+- Item:
+    Item: 6CE001:Update.esm
+    Count: 8
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 00088C:Kad_MoonMonkRobes.esp
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  Unknown2: 84
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 0CB40F:Skyrim.esm
+  ComparisonValue: 1
+CreatedObject: 0008D1:GTS CE - Easy Mode.esp
+WorkbenchKeyword: 6CE000:Update.esm
+CreatedObjectCount: 1

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesRegal - 0008DE_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesRegal - 0008DE_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,27 @@
+FormKey: 0008DE:GTS CE - Easy Mode.esp
+EditorID: CE_0RecipeArmorKhajiitRobesRegal
+Items:
+- Item:
+    Item: 05AD9E:Skyrim.esm
+    Count: 2
+- Item:
+    Item: 05AD9F:Skyrim.esm
+    Count: 1
+- Item:
+    Item: 6CE001:Update.esm
+    Count: 8
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 00088C:Kad_MoonMonkRobes.esp
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  Unknown2: 84
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 0CB40F:Skyrim.esm
+  ComparisonValue: 1
+CreatedObject: 0008D5:GTS CE - Easy Mode.esp
+WorkbenchKeyword: 6CE000:Update.esm
+CreatedObjectCount: 1

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesWater - 0008DF_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesWater - 0008DF_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,27 @@
+FormKey: 0008DF:GTS CE - Easy Mode.esp
+EditorID: CE_0RecipeArmorKhajiitRobesWater
+Items:
+- Item:
+    Item: 05AD9E:Skyrim.esm
+    Count: 2
+- Item:
+    Item: 05AD9F:Skyrim.esm
+    Count: 1
+- Item:
+    Item: 6CE001:Update.esm
+    Count: 8
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 00088C:Kad_MoonMonkRobes.esp
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  Unknown2: 84
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 0CB40F:Skyrim.esm
+  ComparisonValue: 1
+CreatedObject: 0008D6:GTS CE - Easy Mode.esp
+WorkbenchKeyword: 6CE000:Update.esm
+CreatedObjectCount: 1

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesWaterALT - 0008E1_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesWaterALT - 0008E1_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,27 @@
+FormKey: 0008E1:GTS CE - Easy Mode.esp
+EditorID: CE_0RecipeArmorKhajiitRobesWaterALT
+Items:
+- Item:
+    Item: 05AD9E:Skyrim.esm
+    Count: 2
+- Item:
+    Item: 05AD9F:Skyrim.esm
+    Count: 1
+- Item:
+    Item: 6CE001:Update.esm
+    Count: 8
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 00088C:Kad_MoonMonkRobes.esp
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  Unknown2: 84
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 0CB40F:Skyrim.esm
+  ComparisonValue: 1
+CreatedObject: 0008D0:GTS CE - Easy Mode.esp
+WorkbenchKeyword: 6CE000:Update.esm
+CreatedObjectCount: 1

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesWhite - 0008E0_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/ConstructibleObjects/CE_0RecipeArmorKhajiitRobesWhite - 0008E0_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,27 @@
+FormKey: 0008E0:GTS CE - Easy Mode.esp
+EditorID: CE_0RecipeArmorKhajiitRobesWhite
+Items:
+- Item:
+    Item: 05AD9E:Skyrim.esm
+    Count: 2
+- Item:
+    Item: 05AD9F:Skyrim.esm
+    Count: 1
+- Item:
+    Item: 6CE001:Update.esm
+    Count: 8
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 00088C:Kad_MoonMonkRobes.esp
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  Unknown2: 84
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 0CB40F:Skyrim.esm
+  ComparisonValue: 1
+CreatedObject: 0008CF:GTS CE - Easy Mode.esp
+WorkbenchKeyword: 6CE000:Update.esm
+CreatedObjectCount: 1

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/RecordData.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/RecordData.yaml
@@ -96,31 +96,33 @@ ModHeader:
     FileSize: 0
   - Master: Shrine2Kyne.esp
     FileSize: 0
+  - Master: Kad_MoonMonkRobes.esp
+    FileSize: 0
   - Master: HearthfireBathsAll.esp
+    FileSize: 0
+  - Master: Stress and Fear.esp
+    FileSize: 0
+  - Master: Hex - Stress and Fear.esp
+    FileSize: 0
+  - Master: SkillsOfTheWild.esp
     FileSize: 0
   - Master: HandtoHand.esp
     FileSize: 0
-  - Master: Alchemy Requires Bottles Redux.esp
-    FileSize: 0
   - Master: Scion.esp
     FileSize: 0
-  - Master: AdamantBard - Pilgrim Patch.esp
+  - Master: KR2's Aesthetic Androsseus.esp
     FileSize: 0
-  - Master: SkillsOfTheWild.esp
+  - Master: Alchemy Requires Bottles Redux.esp
+    FileSize: 0
+  - Master: AdamantBard - Pilgrim Patch.esp
     FileSize: 0
   - Master: FollowerDeathChance.esp
     FileSize: 0
   - Master: Smart_NPC_Potions.esp
     FileSize: 0
-  - Master: Stress and Fear.esp
-    FileSize: 0
   - Master: SunAffectsNPCVampires.esp
     FileSize: 0
   - Master: The Book of Origins.esp
-    FileSize: 0
-  - Master: KR2's Aesthetic Androsseus.esp
-    FileSize: 0
-  - Master: Hex - Stress and Fear.esp
     FileSize: 0
   - Master: AlternatePerspective.esp
     FileSize: 0
@@ -136,9 +138,9 @@ ModHeader:
     FileSize: 0
   - Master: GTS Patches - Scion.esp
     FileSize: 0
-  - Master: GTS Patches - Remove Rubble Hotfix.esp
-    FileSize: 0
   - Master: GTS CE - Magic.esp
+    FileSize: 0
+  - Master: GTS Patches - Remove Rubble Hotfix.esp
     FileSize: 0
   - Master: GTS CE - Shrines.esp
     FileSize: 0


### PR DESCRIPTION
This commit adds an unarmored variant of the Moon Monk robes.
They require the book perk, Gold, Moonstone, and Thread to craft at a Loom.