### PR TITLE
Add icons to inventory objects

### DIFF
--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_DrumAmazing - 0008ED_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_DrumAmazing - 0008ED_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,17 @@
+FormKey: 0008ED:GTS CE - Easy Mode.esp
+EditorID: CE_DrumAmazing
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D63:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 100
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_DrumBad - 0008E9_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_DrumBad - 0008E9_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,23 @@
+FormKey: 0008E9:GTS CE - Easy Mode.esp
+EditorID: CE_DrumBad
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D63:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 20
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D63:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 40
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_DrumGood - 0008EB_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_DrumGood - 0008EB_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,23 @@
+FormKey: 0008EB:GTS CE - Easy Mode.esp
+EditorID: CE_DrumGood
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D63:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 60
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D63:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 80
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_DrumGreat - 0008EC_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_DrumGreat - 0008EC_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,23 @@
+FormKey: 0008EC:GTS CE - Easy Mode.esp
+EditorID: CE_DrumGreat
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D63:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 80
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D63:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 100
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_DrumHorrible - 0008E8_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_DrumHorrible - 0008E8_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,17 @@
+FormKey: 0008E8:GTS CE - Easy Mode.esp
+EditorID: CE_DrumHorrible
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D63:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 20
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_DrumMid - 0008EA_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_DrumMid - 0008EA_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,23 @@
+FormKey: 0008EA:GTS CE - Easy Mode.esp
+EditorID: CE_DrumMid
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D63:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 40
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D63:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 60
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_FluteAmazing - 0008E7_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_FluteAmazing - 0008E7_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,17 @@
+FormKey: 0008E7:GTS CE - Easy Mode.esp
+EditorID: CE_FluteAmazing
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D61:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 100
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_FluteBad - 0008E3_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_FluteBad - 0008E3_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,23 @@
+FormKey: 0008E3:GTS CE - Easy Mode.esp
+EditorID: CE_FluteBad
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D61:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 20
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D61:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 40
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_FluteGood - 0008E5_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_FluteGood - 0008E5_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,23 @@
+FormKey: 0008E5:GTS CE - Easy Mode.esp
+EditorID: CE_FluteGood
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D61:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 60
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D61:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 80
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_FluteGreat - 0008E6_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_FluteGreat - 0008E6_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,23 @@
+FormKey: 0008E6:GTS CE - Easy Mode.esp
+EditorID: CE_FluteGreat
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D61:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 80
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D61:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 100
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_FluteHorrible - 0008E2_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_FluteHorrible - 0008E2_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,17 @@
+FormKey: 0008E2:GTS CE - Easy Mode.esp
+EditorID: CE_FluteHorrible
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D61:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 20
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_FluteMid - 0008E4_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_FluteMid - 0008E4_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,23 @@
+FormKey: 0008E4:GTS CE - Easy Mode.esp
+EditorID: CE_FluteMid
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D61:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 40
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D61:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 60
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_LuteAmazing - 0008F3_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_LuteAmazing - 0008F3_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,17 @@
+FormKey: 0008F3:GTS CE - Easy Mode.esp
+EditorID: CE_LuteAmazing
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D62:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 100
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_LuteBad - 0008EF_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_LuteBad - 0008EF_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,23 @@
+FormKey: 0008EF:GTS CE - Easy Mode.esp
+EditorID: CE_LuteBad
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D62:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 20
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D62:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 40
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_LuteGood - 0008F1_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_LuteGood - 0008F1_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,23 @@
+FormKey: 0008F1:GTS CE - Easy Mode.esp
+EditorID: CE_LuteGood
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D62:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 60
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D62:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 80
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_LuteGreat - 0008F2_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_LuteGreat - 0008F2_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,23 @@
+FormKey: 0008F2:GTS CE - Easy Mode.esp
+EditorID: CE_LuteGreat
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D62:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 80
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D62:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 100
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_LuteHorrible - 0008EE_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_LuteHorrible - 0008EE_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,17 @@
+FormKey: 0008EE:GTS CE - Easy Mode.esp
+EditorID: CE_LuteHorrible
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D62:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 20
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_LuteMid - 0008F0_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_LuteMid - 0008F0_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,23 @@
+FormKey: 0008F0:GTS CE - Easy Mode.esp
+EditorID: CE_LuteMid
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D62:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 40
+- MutagenObjectType: ConditionFloat
+  CompareOperator: LessThan
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000D62:SkyrimsGotTalent-Bards.esp
+  ComparisonValue: 60
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_AkaviriRoots - 0008F5_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_AkaviriRoots - 0008F5_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 0008F5:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_AkaviriRoots
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 000820:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BackToBasics - 0008F6_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BackToBasics - 0008F6_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 0008F6:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BackToBasics
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 000D6B:Biggie Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BoneCarver - 0008F7_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BoneCarver - 0008F7_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 0008F7:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BoneCarver
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 000829:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookClaw - 000915_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookClaw - 000915_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000915:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookClaw
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 1B400E:NewArmoury.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookColovian - 000917_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookColovian - 000917_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000917:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookColovian
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000855:GTS Patches - OWL.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookCrossbowDawnguard - 000908_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookCrossbowDawnguard - 000908_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000908:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookCrossbowDawnguard
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000807:GTS Patches - Smithing Clean Up.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookCrossbowEbony - 000909_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookCrossbowEbony - 000909_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000909:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookCrossbowEbony
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: Yes, this is Ebony crossbow
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000808:GTS Patches - Smithing Clean Up.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookCrossbowImperial - 000907_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookCrossbowImperial - 000907_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000907:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookCrossbowImperial
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000806:GTS Patches - Smithing Clean Up.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookCrossbowOrcish - 000905_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookCrossbowOrcish - 000905_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000905:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookCrossbowOrcish
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: Yes, this is Orcish crossbows.
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000803:GTS Patches - Smithing Clean Up.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookCrossbowStormcloak - 000906_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookCrossbowStormcloak - 000906_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000906:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookCrossbowStormcloak
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000804:GTS Patches - Smithing Clean Up.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookCrossbowTuskpiercer - 00090A_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookCrossbowTuskpiercer - 00090A_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 00090A:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookCrossbowTuskpiercer
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: Yes, this is Tuskpiercer crossbow
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000805:GTS Patches - Smithing Clean Up.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookExtendedIron - 00090C_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookExtendedIron - 00090C_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 00090C:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookExtendedIron
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000DD8:GTS - New Armors.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookExtendedLeather - 00090E_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookExtendedLeather - 00090E_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 00090E:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookExtendedLeather
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000DDD:GTS - New Armors.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookHalberd - 000911_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookHalberd - 000911_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000911:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookHalberd
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 1B400C:NewArmoury.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookJewellery - 00090B_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookJewellery - 00090B_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 00090B:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookJewellery
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000DD2:GTS - New Armors.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookKatana - 000914_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookKatana - 000914_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000914:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookKatana
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 358B93:NewArmoury.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookMoonMonk - 000918_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookMoonMonk - 000918_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000918:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookMoonMonk
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasPerkConditionData
+    Perk: 00088C:Kad_MoonMonkRobes.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookQuarterstaff - 00090F_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookQuarterstaff - 00090F_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 00090F:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookQuarterstaff
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 1B400D:NewArmoury.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookRapier - 000912_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookRapier - 000912_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000912:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookRapier
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 1B400A:NewArmoury.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookSilver - 00090D_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookSilver - 00090D_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 00090D:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookSilver
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000DD1:GTS - New Armors.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookSpear - 000910_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookSpear - 000910_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000910:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookSpear
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 1B400B:NewArmoury.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookWhip - 000913_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookWhip - 000913_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000913:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookWhip
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 31BD69:NewArmoury.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookWizardHat - 000916_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_BookWizardHat - 000916_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000916:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_BookWizardHat
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: GetGlobalValueConditionData
+    Global: 000863:Wizard Hats Lite Integration.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_CombatMonk - 0008F8_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_CombatMonk - 0008F8_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 0008F8:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_CombatMonk
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 000819:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_DaedricInflunece - 0008F9_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_DaedricInflunece - 0008F9_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 0008F9:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_DaedricInflunece
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 000823:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_DwarvenCraft - 0008FA_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_DwarvenCraft - 0008FA_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 0008FA:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_DwarvenCraft
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 0008A8:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_ElevnSupremacy - 0008FB_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_ElevnSupremacy - 0008FB_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 0008FB:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_ElevnSupremacy
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 000875:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_Flayer - 0008FC_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_Flayer - 0008FC_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 0008FC:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_Flayer
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 00080A:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_FormerForsworn - 0008FD_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_FormerForsworn - 0008FD_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 0008FD:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_FormerForsworn
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 00087B:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_Impaler - 0008FF_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_Impaler - 0008FF_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 0008FF:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_Impaler
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 000806:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_ImperialLoyalist - 0008FE_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_ImperialLoyalist - 0008FE_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 0008FE:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_ImperialLoyalist
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 00086C:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_OneEyed - 000900_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_OneEyed - 000900_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000900:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_OneEyed
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 000858:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_Pilgrim - 000901_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_Pilgrim - 000901_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000901:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_Pilgrim
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 000D67:Biggie Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_RaisedByOrcs - 000902_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_RaisedByOrcs - 000902_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000902:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_RaisedByOrcs
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 00081C:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_ShortSighted - 000903_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_ShortSighted - 000903_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000903:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_ShortSighted
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 000857:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_StormcloakRebel - 000904_GTS CE - Easy Mode.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/Perks/CE_TraitIcon_StormcloakRebel - 000904_GTS CE - Easy Mode.esp.yaml
@@ -1,0 +1,16 @@
+FormKey: 000904:GTS CE - Easy Mode.esp
+EditorID: CE_TraitIcon_StormcloakRebel
+Name:
+  TargetLanguage: English
+  Value: For DIII
+Description:
+  TargetLanguage: English
+  Value: ''
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Data:
+    MutagenObjectType: HasMagicEffectConditionData
+    MagicEffect: 00086B:GTS_Traits.esp
+  ComparisonValue: 1
+NumRanks: 1
+Playable: True

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/RecordData.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/RecordData.yaml
@@ -146,4 +146,10 @@ ModHeader:
     FileSize: 0
   - Master: GTS - Easy Mode.esp
     FileSize: 0
+  - Master: SkyrimsGotTalent-Bards.esp
+    FileSize: 0
+  - Master: 00Taliesin.esp
+    FileSize: 0
+  - Master: Biggie Traits.esp
+    FileSize: 0
   INCC: 1

--- a/GTS CE - Main Patch/GTS CE - Easy Mode/RecordData.yaml
+++ b/GTS CE - Main Patch/GTS CE - Easy Mode/RecordData.yaml
@@ -152,4 +152,16 @@ ModHeader:
     FileSize: 0
   - Master: Biggie Traits.esp
     FileSize: 0
+  - Master: CrossbowIntegration.esp
+    FileSize: 0
+  - Master: GTS Patches - Smithing Clean Up.esp
+    FileSize: 0
+  - Master: GTS - New Armors.esp
+    FileSize: 0
+  - Master: NewArmoury.esp
+    FileSize: 0
+  - Master: GTS Patches - OWL.esp
+    FileSize: 0
+  - Master: Wizard Hats Lite Integration.esp
+    FileSize: 0
   INCC: 1

--- a/GTS CE - Main Patch/GTS CE - Traits Rebalanced/Spells/Traits_ElementalConduitAb - 000058_Biggie Traits.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Traits Rebalanced/Spells/Traits_ElementalConduitAb - 000058_Biggie Traits.esp.yaml
@@ -2,7 +2,7 @@ FormKey: 000058:Biggie Traits.esp
 EditorID: Traits_ElementalConduitAb
 Name:
   TargetLanguage: English
-  Value: >
+  Value: >+
     Natural Conduit
 EquipmentType: 013F44:Skyrim.esm
 Description:

--- a/GTS CE - Main Patch/GTS CE - Traits Rebalanced/Spells/Traits_StormcloakAb - 00086E_GTS_Traits.esp.yaml
+++ b/GTS CE - Main Patch/GTS CE - Traits Rebalanced/Spells/Traits_StormcloakAb - 00086E_GTS_Traits.esp.yaml
@@ -7,6 +7,9 @@ EquipmentType: 013F44:Skyrim.esm
 Description:
   TargetLanguage: English
   Value: While wearing a Stormcloak cuirass, your power attacks deal <15>% more damage, and your Magic Resistance is increased by <10>%.
+Flags:
+- IgnoreResistance
+- NoAbsorbOrReflect
 Type: Ability
 Effects:
 - BaseEffect: 00086B:GTS_Traits.esp

--- a/GTS CE - Main Patch/SKSE/Plugins/DIII/GTS_CE_Icons.json
+++ b/GTS CE - Main Patch/SKSE/Plugins/DIII/GTS_CE_Icons.json
@@ -1,0 +1,225 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JerryYOJ/Dynamic-Inventory-Icon-Injector-SKSE/refs/heads/master/schema.json",
+  "rules": [
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Eighth_Broken"
+      },
+      "match": {
+        "formId": ["Skyrim.esm|0x0daba7", "Skyrim.esm|0x105177", "Skyrim.esm|0x105109", "00Taliesin.esp|0xad22c9"],
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8e2"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Eighth_Broken"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8e8",
+        "formId": "Skyrim.esm|0x0DABA9"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Eighth_Broken"
+      },
+      "match": {
+        "formId": "Skyrim.esm|0x0DABAB",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8ee"
+      }
+    },
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Quarter"
+      },
+      "match": {
+        "formId": ["Skyrim.esm|0x0daba7", "Skyrim.esm|0x105177", "Skyrim.esm|0x105109", "00Taliesin.esp|0xad22c9"],
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8e3"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Quarter"
+      },
+      "match": {
+        "formId": "Skyrim.esm|0x0DABA9",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8e9"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Quarter"
+      },
+      "match": {
+        "formId": "Skyrim.esm|0x0DABAB",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8ef"
+      }
+    },
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Eighth"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8e4",
+        "formId": ["Skyrim.esm|0x0daba7", "Skyrim.esm|0x105177", "Skyrim.esm|0x105109", "00Taliesin.esp|0xad22c9"]
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Eighth"
+      },
+      "match": {
+        "formId": "Skyrim.esm|0x0DABA9",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8ea"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Eighth"
+      },
+      "match": {
+        "formId": "Skyrim.esm|0x0DABAB",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f0"
+      }
+    },
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Beamed"
+      },
+      "match": {
+        "formId": ["Skyrim.esm|0x0daba7", "Skyrim.esm|0x105177", "Skyrim.esm|0x105109", "00Taliesin.esp|0xad22c9"],
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8e5"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Beamed"
+      },
+      "match": {
+        "formId": "Skyrim.esm|0x0DABA9",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8eb"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Beamed"
+      },
+      "match": {
+        "formId": "Skyrim.esm|0x0DABAB",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f1"
+      }
+    },
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Treble_Clef"
+      },
+      "match": {
+        "formId": ["Skyrim.esm|0x0daba7", "Skyrim.esm|0x105177", "Skyrim.esm|0x105109", "00Taliesin.esp|0xad22c9"],
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8e6"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Treble_Clef"
+      },
+      "match": {
+        "formId": "Skyrim.esm|0x0DABA9",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8ec"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Treble_Clef"
+      },
+      "match": {
+        "formId": "Skyrim.esm|0x0DABAB",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f2"
+      }
+    },
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Treble_Clef_Gold"
+      },
+      "match": {
+        "formId": ["Skyrim.esm|0x0daba7", "Skyrim.esm|0x105177", "Skyrim.esm|0x105109", "00Taliesin.esp|0xad22c9"],
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8e7"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Treble_Clef_Gold"
+      },
+      "match": {
+        "formId": "Skyrim.esm|0x0DABA9",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8ed"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Treble_Clef_Gold"
+      },
+      "match": {
+        "formId": "Skyrim.esm|0x0DABAB",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f3"
+      }
+    },
+
+
+
+
+
+    
+    
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Imperial"
+      },
+      "match": {
+        "keywords": "ImmAggrOppsImperialSideArmor"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Stormcloak"
+      },
+      "match": {
+        "keywords": "ImmAggrOppsStormcloakSideArmor"
+      }
+    }
+  ]
+}

--- a/GTS CE - Main Patch/SKSE/Plugins/DIII/GTS_CE_Icons.json
+++ b/GTS CE - Main Patch/SKSE/Plugins/DIII/GTS_CE_Icons.json
@@ -220,6 +220,478 @@
       "match": {
         "keywords": "ImmAggrOppsStormcloakSideArmor"
       }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x03209c",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x905"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x03209a",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x906"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x032098",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x907"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x032096",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x908"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x032094",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x909"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x02d15a",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x90a"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x02d15a",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x90a"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "GTS - New Armors.esp|0xdd4",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x90b"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "GTS - New Armors.esp|0xdd3",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x90c"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "GTS - New Armors.esp|0xdd5",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x90d"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "GTS - New Armors.esp|0xdde",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x90e"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x35dca4",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x90f"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x358b95",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x910"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x35dca3",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x911"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x35dca5",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x912"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x35dca6",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x913"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x35dca7",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x914"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x35dca8",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x915"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "Wizard Hats Lite Integration.esp|0x861",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x916"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "GTS Patches - OWL.esp|0x854",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x917"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer"
+      },
+      "match": {
+        "formId": "Kad_MoonMonkRobes.esp|0x88d",
+        "not": {
+          "conditionPerk": "GTS CE - Easy Mode.esp|0x918"
+        }
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x03209c",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x905"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x03209a",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x906"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x032098",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x907"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x032096",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x908"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x032094",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x909"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x02d15a",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x90a"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "Faction Crossbows.esp|0x02d15a",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x90a"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "GTS - New Armors.esp|0xdd4",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x90b"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "GTS - New Armors.esp|0xdd3",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x90c"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "GTS - New Armors.esp|0xdd5",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x90d"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "GTS - New Armors.esp|0xdde",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x90e"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x35dca4",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x90f"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x358b95",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x910"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x35dca3",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x911"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x35dca5",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x912"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x35dca6",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x913"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x35dca7",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x914"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "NewArmoury.esp|0x35dca8",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x915"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "Wizard Hats Lite Integration.esp|0x861",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x916"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "GTS Patches - OWL.esp|0x854",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x917"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Anvil_Hammer_Ticked"
+      },
+      "match": {
+        "formId": "Kad_MoonMonkRobes.esp|0x88d",
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x918"
+      }
     }
   ]
 }

--- a/GTS CE - Main Patch/SKSE/Plugins/DIII/GTS_CE_Icons.json
+++ b/GTS CE - Main Patch/SKSE/Plugins/DIII/GTS_CE_Icons.json
@@ -692,6 +692,55 @@
         "formId": "Kad_MoonMonkRobes.esp|0x88d",
         "conditionPerk": "GTS CE - Easy Mode.esp|0x918"
       }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Survival_Cold"
+      },
+      "match": {
+        "keywords": "Survival_ArmorCold",
+        "not": {
+          "keywords": "Survival_ArmorWarm"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Survival_Warm"
+      },
+      "match": {
+        "keywords": "Survival_ArmorWarm"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sussy"
+      },
+      "match": {
+        "keywords": "ArmorSuspicious"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Bowtie"
+      },
+      "match": {
+        "keywords": "ClothingRich"
+      }
     }
   ]
 }

--- a/GTS CE - Main Patch/SKSE/Plugins/DIII/GTS_CE_TraitIcons.json
+++ b/GTS CE - Main Patch/SKSE/Plugins/DIII/GTS_CE_TraitIcons.json
@@ -1,0 +1,589 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JerryYOJ/Dynamic-Inventory-Icon-Injector-SKSE/refs/heads/master/schema.json",
+  "rules": [
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f5",
+        "keywords": "WeapTypeKatana"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f5",
+        "keywords": "WeapTypeAkaviri"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f5",
+        "keywords": "ArmorMaterialBlades"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f6",
+        "keywords": "WeapMaterialWood"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f6",
+        "keywords": "WeapMaterialIron"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f6",
+        "keywords": "ArmorMaterialHide"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f6",
+        "keywords": "ArmorMaterialIron"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f6",
+        "keywords": "ArmorMaterialIronBanded"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f6",
+        "keywords": "ArmorMaterialBearStormcloak"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f6",
+        "keywords": "ArmorMaterialForsworn"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f7",
+        "keywords": "WAF_MaterialBonemold"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f7",
+        "keywords": "DLC1WeapMaterialDragonbone"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f7",
+        "keywords": "DLC2ArmorMaterialBonemoldHeavy"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f7",
+        "keywords": "DLC2ArmorMaterialBonemoldLight"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f7",
+        "keywords": "ArmorMaterialDragonplate"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f7",
+        "keywords": "ArmorMaterialDragonscale"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f8",
+        "keywords": "WeapTypeQtrStaff"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f9",
+        "keywords": "VendorItemDaedricArtifact"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f9",
+        "keywords": "ArmorMaterialDaedric"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f9",
+        "keywords": "ccBGSSSE025_ArmorMaterialDark"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f9",
+        "keywords": "ccBGSSSE025_ArmorMaterialAmber"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f9",
+        "keywords": "ccBGSSSE025_ArmorMaterialGolden"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f9",
+        "keywords": "ccBGSSSE025_ArmorMaterialMadness"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f9",
+        "keywords": "WeapMaterialDaedric",
+        "not": {
+          "keywords": "DaedricArtifact"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f9",
+        "keywords": "ccBGSSSE025_WeapMaterialAmber"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f9",
+        "keywords": "ccBGSSSE025_WeapMaterialDark"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f9",
+        "keywords": "ccBGSSSE025_WeapMaterialGolden"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8f9",
+        "keywords": "ccBGSSSE025_WeapMaterialMadness"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8fa",
+        "keywords": "WeapMaterialDwarven"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8fa",
+        "keywords": "ArmorMaterialDwarven"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8fb",
+        "keywords": "WeapMaterialElven"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8fb",
+        "keywords": "WeapMaterialGlass"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8fb",
+        "keywords": "ArmorMaterialElven"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8fb",
+        "keywords": "ArmorMaterialGlass"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8fc",
+        "keywords": "WeapTypeWhip"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8fd",
+        "keywords": "ArmorMaterialForsworn"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8fe",
+        "keywords": "ImmAggrOppsImperialSideArmor"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8ff",
+        "keywords": "WeapTypeHalberd"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8ff",
+        "keywords": "WeapTypePike"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x8ff",
+        "keywords": "WeapTypeShortspear"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x900",
+        "keywords": "EyePatchKeyword"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x901",
+        "keywords": "PilgrimAmulet"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun_Red"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x901",
+        "keywords": "DaedricArtifact"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun_Red"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x901",
+        "keywords": "WeapMaterialDaedric",
+        "not": {
+          "keywords": "DaedricArtifact"
+        }
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun_Red"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x901",
+        "keywords": "ArmorDaedricShieldDUPLICATE001"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun_Red"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x901",
+        "keywords": "ArmorMaterialDaedric",
+        "not": {
+          "keywords": "DPA_ArmorDragonPriest"
+        }
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x902",
+        "keywords": "WeapMaterialOrcish"
+      }
+    },
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x902",
+        "keywords": "ArmorMaterialOrcish"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x903",
+        "keywords": "EyeGlassesKeyword"
+      }
+    },
+
+
+
+
+
+    {
+      "icon": {
+        "source": "GTS CE/CE_Sprites.swf",
+        "label": "Icon_Sun"
+      },
+      "match": {
+        "conditionPerk": "GTS CE - Easy Mode.esp|0x903",
+        "keywords": "ImmAggrOppsStormcloakSideArmor"
+      }
+    }
+  ]
+}

--- a/Modlist.md
+++ b/Modlist.md
@@ -97,6 +97,7 @@ The mods are listed as they're named in Vortex. The exact names may differ sligh
         - Dungeon Water Loops
         - Word Walls
     - Music Options = Add-On
+- DynamicInventoryIconInjector
 - Echoes of Tamriel - Loading Screens - 2k
 - Enchantment Art Extender
 - Enchantment Art Extender - Vibrant Weapons - EAE
@@ -188,6 +189,7 @@ The mods are listed as they're named in Vortex. The exact names may differ sligh
 - Highlight Quest Markers
 - House Cats - My version SE by Xtudo - FluffyC 2K
 - I'm Walkin' Here NG with Pets
+- Immersive Spell Learning - DESTified Study Icon
 - Improved Loading Screen Colors
 - Increased Floating Quest Marker Distance (GSO)
 - Infinity UI
@@ -257,6 +259,7 @@ The mods are listed as they're named in Vortex. The exact names may differ sligh
 - Pilgrim Religion Overhaul - Shrines fit for the Divine - Fists of Fury - NR Combo Patch
 - Pilgrim Religion Overhaul - Shrines fit for the Divine - Fists of Fury Patch
 - Pilgrim Religion Overhaul - Shrines fit for the Divine - Northern Roads Patch
+- QuestItemIcon
 - Read The Dragon Shout
 - Revenant Spirits of the Soul Cairn
     - Thank you for downloading! = Revenant Spirits of the Soul Cairn


### PR DESCRIPTION
Use [Dynamic Inventory Icon Injector](https://www.nexusmods.com/skyrimspecialedition/mods/174136) to add various icons to inventory objects.

Two other mods will also be included:
- [QuestItemIcon](https://www.nexusmods.com/skyrimspecialedition/mods/174141)
- [Immersive Spell Learning - DESTified Study Icon](https://www.nexusmods.com/skyrimspecialedition/mods/174815)

Current ideas for additional icons are:

- [x] Civil War armors or factions / disguise
- [x] Items affected by current traits
- [x] Special icons for instruments, based on skill level
- [x] ~~Misc objects that can be activated from inventory~~
- [x] Survival Mode warmth
- [x] Crafting books
- [x] GTS - OWL Suspicious keyword
- [x] Expensive clothing
- [x] Add the icon file to the CE Assets archive

Any other ideas are welcome.